### PR TITLE
quote包裹住relative标志，避免html结构错乱造成html-minifier调用失败

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function onStandardRestoreUri(message) {
     return;
   }
 
-  message.ret = wrap(info.quote + info.file.subpath + info.query + info.quote);
+  message.ret = info.quote + wrap(info.file.subpath + info.query) + info.quote;
 };
 
 function onProcessEnd(file) {


### PR DESCRIPTION
使用html-minifier压缩html时，因为relative标志问题，造成错误
```
Parse Error: <link rel="stylesheet" type="text/css" href=__relative("/demo/index.css") />
```
先在将relative标志用引号包裹起来，中间内容链接不使用引号， 改写后该片段将输出
```
<link rel="stylesheet" type="text/css" href="__relative(/demo/index.css)" />
```
不影响html结构