### PR TITLE
修复对URL中hash不支持的问题,example with css background:url('./path/sprite.svg#…

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function onStandardRestoreUri(message) {
     return;
   }
 
-  message.ret = wrap(info.quote + info.file.subpath + info.query + info.quote);
+  message.ret = wrap(info.quote + info.file.subpath + info.query + info.hash + info.quote);
 };
 
 function onProcessEnd(file) {


### PR DESCRIPTION
relative issue: 
https://github.com/fex-team/fis3/issues/1221 #1221  
https://github.com/fex-team/fis3/issues/1105 #1105 